### PR TITLE
Přehled adres pro Berana

### DIFF
--- a/app/controllers/backoffice/people_controller.rb
+++ b/app/controllers/backoffice/people_controller.rb
@@ -47,10 +47,11 @@ class Backoffice::PeopleController < ApplicationController
   end
 
   def new_registrations
-    # stara verze...
-    # @people = Person.order(id: :desc).limit(50)
-    # ukol zni: nove registrace za posledni 3 mesice => 50 je malo
-    @people = Person.order(id: :desc).limit(500)
+    @people = Person.order(id: :desc).limit(50)
+  end
+  
+  def with_unknown_address
+    @people = Person.includes([:domestic_region, :signed_application]).select{|p| p.is_regular?}
   end
 
   # GET /people/1

--- a/app/controllers/backoffice/people_controller.rb
+++ b/app/controllers/backoffice/people_controller.rb
@@ -50,7 +50,7 @@ class Backoffice::PeopleController < ApplicationController
     @people = Person.order(id: :desc).limit(50)
   end
   
-  def with_unknown_address
+  def active_addresses
     @people = Person.includes([:domestic_region, :signed_application]).select{|p| p.is_regular?}
   end
 

--- a/app/controllers/backoffice/people_controller.rb
+++ b/app/controllers/backoffice/people_controller.rb
@@ -47,7 +47,10 @@ class Backoffice::PeopleController < ApplicationController
   end
 
   def new_registrations
-    @people = Person.order(id: :desc).limit(50)
+    # stara verze...
+    # @people = Person.order(id: :desc).limit(50)
+    # ukol zni: nove registrace za posledni 3 mesice => 50 je malo
+    @people = Person.order(id: :desc).limit(500)
   end
 
   # GET /people/1

--- a/app/views/backoffice/_sidebar.html.erb
+++ b/app/views/backoffice/_sidebar.html.erb
@@ -10,6 +10,7 @@
         <li><%= link_to_unless_current "Členové bez přihlášky", members_without_signed_application_backoffice_people_path %></li>
         <li><%= link_to_unless_current "Špatný kraj", with_bad_region_backoffice_people_path %></li>
         <li><%= link_to_unless_current "Nové registrace", new_registrations_backoffice_people_path %></li>
+        <li><%= link_to_unless_current "Adresy - Beran", active_addresses_backoffice_people_path %></li>
       </ul>
     </li>
     <% if can? :destroy, Role %>

--- a/app/views/backoffice/people/active_addresses.html.erb
+++ b/app/views/backoffice/people/active_addresses.html.erb
@@ -1,0 +1,19 @@
+<%
+  page_title "Adresy aktivních členů a příznivců"
+  render "backoffice/sidebar"
+%>
+
+<table id="people" class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>Jméno</th><th>Kontaktní adresa</th></tr>
+  </thead>
+  <tbody>
+    <% @people.each do |person| %>
+    <tr>
+      <td><%=person.vs%></td>
+      <td><%=link_to person.name, backoffice_person_path(person) %></td>
+      <td><%=t person.postal_address_line%></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
pokus přidat do backoffice odkaz, který vypíše seznam adres všech aktivních členů a příznivců - pro distributory tištěného Berana

časem by měl být doplněn o vyřazení odmítačů Berana (viz Issue #26 )