### PR TITLE
Allow VK members to create roles

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,6 +60,7 @@ class Ability
         elsif role.body.try(:acronym)=="VK"
           # Volební komise + volební systém
           can [:read], Person
+          can [:create], Role
         elsif role.body.try(:acronym)=="KK"
           can :backoffice, :read
         end


### PR DESCRIPTION
In order to allow automatic export from ballot_box to party_registry, vk members needs to be able to to create roles.